### PR TITLE
Fix constant assignment error when using Fahrenheit

### DIFF
--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -370,7 +370,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		this.refreshState()
 		if (this.debug) this.log('Getting Heating Threshold Temperature', this.name)
 	
-		const targetTemp = this.state.acState.targetTemperature
+		let targetTemp = this.state.acState.targetTemperature
 		
 		this.log(this.name + ' Target HEAT Temperature is ' + targetTemp + 'º' + this.temperatureUnit)
 


### PR DESCRIPTION
This fixes an error I'm seeing with the latest version when using Fahrenheit.

```
TypeError: Assignment to constant variable.
    at acAccessory.getHeatingThresholdTemperature (/homebridge/node_modules/homebridge-sensibo-ac/lib/accessories.js:378:15)
    at HeatingThresholdTemperature.emit (events.js:310:20)
    at HeatingThresholdTemperature.EventEmitter.emit (domain.js:482:12)
    at HeatingThresholdTemperature.EventEmitter.emit (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/EventEmitter.ts:42:22)
    at HeatingThresholdTemperature.Characteristic._this.getValue (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:462:12)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Accessory.ts:1215:22
    at Array.forEach (<anonymous>)
    at Bridge.Accessory._this._handleGetCharacteristics (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Accessory.ts:1143:10)
    at HAPServer.emit (events.js:310:20)
    at HAPServer.EventEmitter.emit (domain.js:482:12)
```