### PR TITLE
Use celsius for homebridge target temperatures

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ SensiboACPlatform.prototype = {
 
 						const pods = await sensibo.getDevicesStates()
 
-            if (pods.length) {
+						if (pods.length) {
 							pods.forEach(pod => {
 								if (!this.cachedState.pods[pod.id])
 									this.cachedState.pods[pod.id] = {}

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function SensiboACPlatform(log, config) {
 		this.log('Can\'t start homebridge-sensibo-ac plugin without API KEY !!\n')
 		this.log('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n')
 	}
-	
+
 
 }
 
@@ -87,9 +87,9 @@ SensiboACPlatform.prototype = {
 					try {
 						if (this.debug)
 							this.log('Getting Devices State')
-			
-						const pods = await sensibo.getDevicesStates()
 
+						const pods = await sensibo.getDevicesStates()
+            this.log('Received device states:', pods);
 						if (pods.length) {
 							pods.forEach(pod => {
 								if (!this.cachedState.pods[pod.id])
@@ -100,7 +100,7 @@ SensiboACPlatform.prototype = {
 								const isStateChanged = (this.cachedState.pods[pod.id].acState && JSON.stringify(this.cachedState.pods[pod.id].acState) !== JSON.stringify(pod.acState)) || !this.cachedState.pods[pod.id].acState
 								const isMeasurementsChanged = (this.cachedState.pods[pod.id].measurements && (this.cachedState.pods[pod.id].measurements.temperature !== pod.measurements.temperature || this.cachedState.pods[pod.id].measurements.humidity !== pod.measurements.humidity)) || !this.cachedState.pods[pod.id].measurements
 								const isClimateReactChanged = this.enableClimateReactSwitch && (!this.cachedState.pods[pod.id].smartMode || (this.cachedState.pods[pod.id].smartMode.enabled !== climateReactState))
-								
+
 								let newState = null
 								let newMeasurements = null
 								let newClimateReactState = null
@@ -111,7 +111,7 @@ SensiboACPlatform.prototype = {
 									if (!this.cachedState.pods[pod.id].last)
 										this.cachedState.pods[pod.id].last = {}
 									this.cachedState.pods[pod.id].last[pod.acState.mode] =  pod.acState
-				
+
 									if (pod.acState.mode !== 'fan' && pod.acState.mode !== 'dry')
 										this.cachedState.pods[pod.id].last.mode = pod.acState.mode
 
@@ -159,17 +159,17 @@ SensiboACPlatform.prototype = {
 							this.log('ERROR setting sensibo status to cache!')
 							this.debug(err)
 						}
-						
+
 					} catch(err) {
 						this.processingState = false
 						this.refreshTimeout = setTimeout(this.refreshState, this.pollingInterval)
 						this.log('ERROR getting devices status from API!')
 						if (this.debug)
-							this.log(err) 
+							this.log(err)
 					}
 				}, this.refreshDelay)
 			}
-			
+
 		}
 		let pods = []
 
@@ -180,7 +180,7 @@ SensiboACPlatform.prototype = {
 				await this.refreshState()
 				pods = await sensibo.getAllPods()
 				await storage.setItem('sensibo_pods', pods)
-				
+
 			} catch(err) {
 				this.log('ERROR getting devices status from API!')
 				const cachedPods = await storage.getItem('sensibo_pods')
@@ -230,7 +230,7 @@ SensiboACPlatform.prototype = {
 
 			}
 		} else this.log('No Sensibo devices were detected... Not doing anything!')
-				
+
 		callback(this.returnedAccessories)
 	}
 }

--- a/index.js
+++ b/index.js
@@ -89,8 +89,8 @@ SensiboACPlatform.prototype = {
 							this.log('Getting Devices State')
 
 						const pods = await sensibo.getDevicesStates()
-            this.log('Received device states:', pods);
-						if (pods.length) {
+
+            if (pods.length) {
 							pods.forEach(pod => {
 								if (!this.cachedState.pods[pod.id])
 									this.cachedState.pods[pod.id] = {}

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -354,14 +354,11 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	}
 
 	acAccessory.prototype.setCoolingThresholdTemperature = function (temp, callback) {
-		if (this.temperatureUnit === 'F')
+		if (this.usesFahrenheit())
 			temp = toFahrenheit(temp)
+
 		if (this.debug)
 			this.log(this.name + ' -> Setting Cooling Threshold Temperature:', temp)
-
-		if (this.usesFahrenheit()) {
-			temp = toFahrenheit(temp)
-		}
 
 		this.setNewState('coolTemp', temp)
 		callback()

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -347,7 +347,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		if (this.debug)
 			this.log('Getting Cooling Threshold Temperature', this.name)
 
-		let targetTemp = this.getNormalizedTargetTemperature()
+		let targetTemp = this.getCelsiusTargetTemperature()
 		this.log(this.name + ' Target COOL Temperature is ' + targetTemp + 'º' + CELSIUS_UNIT)
 
 		callback(null, targetTemp)
@@ -370,7 +370,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 
 		this.log(this.name + ' Target HEAT Temperature is ' + this.state.acState.targetTemperature + 'º' + this.temperatureUnit)
 
-		const targetTemp = this.getNormalizedTargetTemperature()
+		const targetTemp = this.getCelsiusTargetTemperature()
 
 		callback(null, targetTemp)
 	}
@@ -714,7 +714,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 			})
 	}
 
-	acAccessory.prototype.getNormalizedTargetTemperature = function () {
+	acAccessory.prototype.getCelsiusTargetTemperature = function () {
 		if (this.usesFahrenheit()) {
 			return toCelsius(this.state.acState.targetTemperature)
 		}
@@ -871,7 +871,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 				if (acState.fanLevel)
 					rotationSpeed = fanLeveltoHK(acState.fanLevel, this.capabilities[acState.mode].fanLevels)
 				if (acState.targetTemperature)
-					targetTemperature = this.getNormalizedTargetTemperature()
+					targetTemperature = this.getCelsiusTargetTemperature()
 
 				// if mode is fan
 				if (acState.mode === 'fan' && !this.setProcessing) {
@@ -975,7 +975,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 
 		if (this.debug && !this.setProcessing && (acState || measurements || smartMode)) {
 			this.log(`Finished updating state in HomeKit for ${this.id}:`)
-			this.log(`Target Temp:`, this.getNormalizedTargetTemperature())
+			this.log(`Target Temp:`, this.getCelsiusTargetTemperature())
 			if (acState)
 				this.log('acState:', acState)
 			if (measurements)

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -81,6 +81,11 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 
 
 		this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentTemperature)
+			.setProps({
+				minValue: -100,
+				maxValue: 100,
+				minStep: 0.1
+			})
 			.on('get', this.getCurrentTemperature.bind(this))
 
 		if (this.capabilities.cool) {
@@ -347,8 +352,9 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		if (this.debug)
 			this.log('Getting Cooling Threshold Temperature', this.name)
 
+		this.log(this.name + ' Target COOL Temperature is ' + this.state.acState.targetTemperature + 'º' + this.temperatureUnit)
+
 		let targetTemp = this.getCelsiusTargetTemperature()
-		this.log(this.name + ' Target COOL Temperature is ' + targetTemp + 'º' + CELSIUS_UNIT)
 
 		callback(null, targetTemp)
 	}
@@ -975,7 +981,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 
 		if (this.debug && !this.setProcessing && (acState || measurements || smartMode)) {
 			this.log(`Finished updating state in HomeKit for ${this.id}:`)
-			this.log(`Target Temp:`, this.getCelsiusTargetTemperature())
+
 			if (acState)
 				this.log('acState:', acState)
 			if (measurements)

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -376,12 +376,11 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	}
 
 	acAccessory.prototype.setHeatingThresholdTemperature = function (temp, callback) {
+		if (this.usesFahrenheit())
+			temp = toFahrenheit(temp)
+
 		if (this.debug)
 			this.log(this.name + ' -> Setting Heating Threshold Temperature:', temp)
-
-		if (this.usesFahrenheit()) {
-			temp = toFahrenheit(temp)
-		}
 
 		this.setNewState('heatTemp', temp)
 		callback()

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -707,7 +707,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 			})
 	}
 
-	acAccessory.prototype.getNormalizedTargetTemperature = () => {
+	acAccessory.prototype.getNormalizedTargetTemperature = function () {
 		if (this.state.acState.temperatureUnit === "F") {
 			return toCelsius(this.state.acState.targetTemperature)
 		}

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -9,8 +9,8 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	/********************************************************************************************************************************************************/
 	/********************************************************************************************************************************************************/
 
-  const CELSIUS_UNIT = 'C'
-  const FAHRENHEIT_UNIT = 'F'
+	const CELSIUS_UNIT = 'C'
+	const FAHRENHEIT_UNIT = 'F'
 
 	function acAccessory(config) {
 
@@ -345,7 +345,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	acAccessory.prototype.getCoolingThresholdTemperature = function (callback) {
 		this.refreshState()
 		if (this.debug)
-      this.log('Getting Cooling Threshold Temperature', this.name)
+			this.log('Getting Cooling Threshold Temperature', this.name)
 
 		let targetTemp = this.getNormalizedTargetTemperature()
 		this.log(this.name + ' Target COOL Temperature is ' + targetTemp + 'º' + CELSIUS_UNIT)
@@ -828,7 +828,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 				this.log(this.name, '*New State* - Relative Humidity -', measurements.humidity, '%')
 			}
 			this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentTemperature).updateValue(measurements.temperature)
-      this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentRelativeHumidity).updateValue(measurements.humidity)
+			this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentRelativeHumidity).updateValue(measurements.humidity)
 			// log new state
 			this.loggingService && this.loggingService.addEntry({ time: Math.floor((new Date()).getTime()/1000), temp: measurements.temperature, humidity: measurements.humidity })
 
@@ -964,6 +964,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 
 		if (this.debug && !this.setProcessing && (acState || measurements || smartMode)) {
 			this.log(`Finished updating state in HomeKit for ${this.id}:`)
+			this.log(`Target Temp:`, this.getNormalizedTargetTemperature())
 			if (acState)
 				this.log('acState:', acState)
 			if (measurements)

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -269,7 +269,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		const mode = this.state.acState.mode
 		const on = this.state.acState.on
 		let targetTemp = this.state.acState.targetTemperature
-		if (this.temperatureUnit === FAHRENHEIT_UNIT)
+		if (this.usesFahrenheit())
 			targetTemp = toCelsius(targetTemp)
 
 		const temp = this.state.measurements.temperature
@@ -334,7 +334,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		if (this.debug) this.log('Getting Room Temperature', this.name)
 
 		let temp = this.state.measurements.temperature
-		if (this.temperatureUnit === FAHRENHEIT_UNIT)
+		if (this.usesFahrenheit())
 			this.log(this.name + ' Current Temperature is ' + toFahrenheit(temp) + 'º' + this.temperatureUnit)
 		else
 			this.log(this.name + ' Current Temperature is ' + temp + 'º' + this.temperatureUnit)
@@ -717,7 +717,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	}
 
 	acAccessory.prototype.getNormalizedTargetTemperature = function () {
-		if (this.state.acState.temperatureUnit === "F") {
+		if (this.usesFahrenheit()) {
 			return toCelsius(this.state.acState.targetTemperature)
 		}
 
@@ -725,8 +725,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	}
 
 	acAccessory.prototype.usesFahrenheit = function () {
-		const tempUnit = this.state.acState && this.state.acState.temperatureUnit || this.temperatureUnit;
-		return tempUnit === FAHRENHEIT_UNIT
+		return this.temperatureUnit === FAHRENHEIT_UNIT
 	}
 
 	acAccessory.prototype.setNewState = function (key, value) {
@@ -838,7 +837,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	acAccessory.prototype.updateHomeKit = function (acState, measurements, smartMode) {
 		if (measurements) {
 			if (this.debug) {
-				this.log(this.name, '*New State* - Room Temperature -', (this.temperatureUnit === FAHRENHEIT_UNIT ? toFahrenheit(measurements.temperature) : measurements.temperature), 'º' + this.temperatureUnit)
+				this.log(this.name, '*New State* - Room Temperature -', (this.usesFahrenheit() ? toFahrenheit(measurements.temperature) : measurements.temperature), 'º' + this.temperatureUnit)
 				this.log(this.name, '*New State* - Relative Humidity -', measurements.humidity, '%')
 			}
 			this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentTemperature).updateValue(measurements.temperature)

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -368,9 +368,9 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		this.refreshState()
 		if (this.debug) this.log('Getting Heating Threshold Temperature', this.name)
 
-		const targetTemp = this.getNormalizedTargetTemperature()
+		this.log(this.name + ' Target HEAT Temperature is ' + this.state.acState.targetTemperature + 'º' + this.temperatureUnit)
 
-		this.log(this.name + ' Target HEAT Temperature is ' + targetTemp + 'º' + CELSIUS_UNIT)
+		const targetTemp = this.getNormalizedTargetTemperature()
 
 		callback(null, targetTemp)
 	}

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -356,6 +356,11 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	acAccessory.prototype.setCoolingThresholdTemperature = function (temp, callback) {
 		if (this.debug)
 			this.log(this.name + ' -> Setting Cooling Threshold Temperature:', temp)
+
+		if (this.usesFahrenheit()) {
+			temp = toFahrenheit(temp)
+		}
+
 		this.setNewState('coolTemp', temp)
 		callback()
 	}
@@ -375,6 +380,10 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		if (this.debug)
 			this.log(this.name + ' -> Setting Heating Threshold Temperature:', temp)
 
+		if (this.usesFahrenheit()) {
+			temp = toFahrenheit(temp)
+		}
+
 		this.setNewState('heatTemp', temp)
 		callback()
 	}
@@ -385,7 +394,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 			this.log('The current temperature display unit is ' + ('º' + this.temperatureUnit))
 		}
 
-		callback(null, this.temperatureUnit === FAHRENHEIT_UNIT ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS)
+		callback(null, this.usesFahrenheit() ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS)
 	}
 
 	acAccessory.prototype.getCurrentRelativeHumidity = function (callback) {
@@ -715,6 +724,11 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		return this.state.acState.targetTemperature
 	}
 
+	acAccessory.prototype.usesFahrenheit = function () {
+		const tempUnit = this.state.acState && this.state.acState.temperatureUnit || this.temperatureUnit;
+		return tempUnit === FAHRENHEIT_UNIT
+	}
+
 	acAccessory.prototype.setNewState = function (key, value) {
 		this.setCommands[key] = value
 		if (this.debug)
@@ -1026,9 +1040,6 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 			this.OccupancySensor.getCharacteristic(Characteristic.OccupancyDetected).updateValue(0)
 		}
 	}
-
-
-
 
 	return {acAccessory, occupancySensor}
 }

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -88,7 +88,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 				.setProps({
 					minValue: this.capabilities.cool.temperatures[CELSIUS_UNIT].values[0],
 					maxValue: this.capabilities.cool.temperatures[CELSIUS_UNIT].values[this.capabilities.cool.temperatures[CELSIUS_UNIT].values.length - 1],
-					minStep: 1
+					minStep: 0.1
 				})
 				.on('get', this.getCoolingThresholdTemperature.bind(this))
 				.on('set', this.setCoolingThresholdTemperature.bind(this))
@@ -99,7 +99,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 				.setProps({
 					minValue: this.capabilities.heat.temperatures[CELSIUS_UNIT].values[0],
 					maxValue: this.capabilities.heat.temperatures[CELSIUS_UNIT].values[this.capabilities.cool.temperatures[CELSIUS_UNIT].values.length - 1],
-					minStep: 1
+					minStep: 0.1
 				})
 				.on('get', this.getHeatingThresholdTemperature.bind(this))
 				.on('set', this.setHeatingThresholdTemperature.bind(this))

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -708,11 +708,11 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	}
 
 	acAccessory.prototype.getNormalizedTargetTemperature = () => {
-		if (this.acState.temperatureUnit === "F") {
-			return toCelsius(this.acState.targetTemperature)
+		if (this.state.acState.temperatureUnit === "F") {
+			return toCelsius(this.state.acState.targetTemperature)
 		}
 
-		return this.acState.targetTemperature
+		return this.state.acState.targetTemperature
 	}
 
 	acAccessory.prototype.setNewState = function (key, value) {
@@ -860,7 +860,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 				if (acState.fanLevel)
 					rotationSpeed = fanLeveltoHK(acState.fanLevel, this.capabilities[acState.mode].fanLevels)
 				if (acState.targetTemperature)
-					targetTemperature = this.temperatureUnit === FAHRENHEIT_UNIT ? toCelsius(acState.targetTemperature) : acState.targetTemperature
+					targetTemperature = this.getNormalizedTargetTemperature()
 
 				// if mode is fan
 				if (acState.mode === 'fan' && !this.setProcessing) {

--- a/lib/accessories.js
+++ b/lib/accessories.js
@@ -9,6 +9,9 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	/********************************************************************************************************************************************************/
 	/********************************************************************************************************************************************************/
 
+  const CELSIUS_UNIT = 'C'
+  const FAHRENHEIT_UNIT = 'F'
+
 	function acAccessory(config) {
 
 		this.type = config.type
@@ -78,18 +81,13 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 
 
 		this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentTemperature)
-			.setProps({
-				minValue: -100,
-				maxValue: 100,
-				minStep: 0.1
-			})
 			.on('get', this.getCurrentTemperature.bind(this))
 
 		if (this.capabilities.cool) {
 			this.HeaterCoolerService.getCharacteristic(Characteristic.CoolingThresholdTemperature)
 				.setProps({
-					minValue: this.capabilities.cool.temperatures[this.temperatureUnit].values[0],
-					maxValue: this.capabilities.cool.temperatures[this.temperatureUnit].values[this.capabilities.cool.temperatures[this.temperatureUnit].values.length - 1],
+					minValue: this.capabilities.cool.temperatures[CELSIUS_UNIT].values[0],
+					maxValue: this.capabilities.cool.temperatures[CELSIUS_UNIT].values[this.capabilities.cool.temperatures[CELSIUS_UNIT].values.length - 1],
 					minStep: 1
 				})
 				.on('get', this.getCoolingThresholdTemperature.bind(this))
@@ -99,8 +97,8 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		if (this.capabilities.heat) {
 			this.HeaterCoolerService.getCharacteristic(Characteristic.HeatingThresholdTemperature)
 				.setProps({
-					minValue: this.capabilities.heat.temperatures[this.temperatureUnit].values[0],
-					maxValue: this.capabilities.heat.temperatures[this.temperatureUnit].values[this.capabilities.cool.temperatures[this.temperatureUnit].values.length - 1],
+					minValue: this.capabilities.heat.temperatures[CELSIUS_UNIT].values[0],
+					maxValue: this.capabilities.heat.temperatures[CELSIUS_UNIT].values[this.capabilities.cool.temperatures[CELSIUS_UNIT].values.length - 1],
 					minStep: 1
 				})
 				.on('get', this.getHeatingThresholdTemperature.bind(this))
@@ -271,7 +269,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		const mode = this.state.acState.mode
 		const on = this.state.acState.on
 		let targetTemp = this.state.acState.targetTemperature
-		if (this.temperatureUnit === 'F')
+		if (this.temperatureUnit === FAHRENHEIT_UNIT)
 			targetTemp = toCelsius(targetTemp)
 
 		const temp = this.state.measurements.temperature
@@ -336,13 +334,10 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 		if (this.debug) this.log('Getting Room Temperature', this.name)
 
 		let temp = this.state.measurements.temperature
-		if (this.temperatureUnit === 'F')
+		if (this.temperatureUnit === FAHRENHEIT_UNIT)
 			this.log(this.name + ' Current Temperature is ' + toFahrenheit(temp) + 'º' + this.temperatureUnit)
 		else
 			this.log(this.name + ' Current Temperature is ' + temp + 'º' + this.temperatureUnit)
-
-		// if (this.temperatureUnit === 'F')
-		// 	temp = toCelsius(temp)
 
 		callback(null, temp)
 	}
@@ -350,11 +345,10 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	acAccessory.prototype.getCoolingThresholdTemperature = function (callback) {
 		this.refreshState()
 		if (this.debug)
-			this.log('Getting Cooling Threshold Temperature', this.name)
-		let targetTemp = this.state.acState.targetTemperature
-		this.log(this.name + ' Target COOL Temperature is ' + targetTemp + 'º' + this.temperatureUnit)
-		if (this.temperatureUnit === 'F')
-			targetTemp = toCelsius(targetTemp)
+      this.log('Getting Cooling Threshold Temperature', this.name)
+
+		let targetTemp = this.getNormalizedTargetTemperature()
+		this.log(this.name + ' Target COOL Temperature is ' + targetTemp + 'º' + CELSIUS_UNIT)
 
 		callback(null, targetTemp)
 	}
@@ -369,20 +363,15 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	acAccessory.prototype.getHeatingThresholdTemperature = function (callback) {
 		this.refreshState()
 		if (this.debug) this.log('Getting Heating Threshold Temperature', this.name)
-	
-		let targetTemp = this.state.acState.targetTemperature
-		
-		this.log(this.name + ' Target HEAT Temperature is ' + targetTemp + 'º' + this.temperatureUnit)
 
-		if (this.temperatureUnit === 'F')
-			targetTemp = toCelsius(targetTemp)
+		const targetTemp = this.getNormalizedTargetTemperature()
+
+		this.log(this.name + ' Target HEAT Temperature is ' + targetTemp + 'º' + CELSIUS_UNIT)
 
 		callback(null, targetTemp)
 	}
 
 	acAccessory.prototype.setHeatingThresholdTemperature = function (temp, callback) {
-		if (this.temperatureUnit === 'F')
-			temp = toFahrenheit(temp)
 		if (this.debug)
 			this.log(this.name + ' -> Setting Heating Threshold Temperature:', temp)
 
@@ -396,7 +385,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 			this.log('The current temperature display unit is ' + ('º' + this.temperatureUnit))
 		}
 
-		callback(null, this.temperatureUnit === 'F' ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS)
+		callback(null, this.temperatureUnit === FAHRENHEIT_UNIT ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS)
 	}
 
 	acAccessory.prototype.getCurrentRelativeHumidity = function (callback) {
@@ -718,6 +707,13 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 			})
 	}
 
+	acAccessory.prototype.getNormalizedTargetTemperature = () => {
+		if (this.acState.temperatureUnit === "F") {
+			return toCelsius(this.acState.targetTemperature)
+		}
+
+		return this.acState.targetTemperature
+	}
 
 	acAccessory.prototype.setNewState = function (key, value) {
 		this.setCommands[key] = value
@@ -828,12 +824,11 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 	acAccessory.prototype.updateHomeKit = function (acState, measurements, smartMode) {
 		if (measurements) {
 			if (this.debug) {
-				this.log(this.name, '*New State* - Room Temperature -', (this.temperatureUnit === 'F' ? toFahrenheit(measurements.temperature) : measurements.temperature), 'º' + this.temperatureUnit)
+				this.log(this.name, '*New State* - Room Temperature -', (this.temperatureUnit === FAHRENHEIT_UNIT ? toFahrenheit(measurements.temperature) : measurements.temperature), 'º' + this.temperatureUnit)
 				this.log(this.name, '*New State* - Relative Humidity -', measurements.humidity, '%')
 			}
 			this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentTemperature).updateValue(measurements.temperature)
-			// this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentTemperature).updateValue(this.temperatureUnit === 'F' ? toCelsius(measurements.temperature) : measurements.temperature )
-			this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentRelativeHumidity).updateValue(measurements.humidity)
+      this.HeaterCoolerService.getCharacteristic(Characteristic.CurrentRelativeHumidity).updateValue(measurements.humidity)
 			// log new state
 			this.loggingService && this.loggingService.addEntry({ time: Math.floor((new Date()).getTime()/1000), temp: measurements.temperature, humidity: measurements.humidity })
 
@@ -865,7 +860,7 @@ module.exports = function (Accessory, Service, Characteristic, HomebridgeAPI, uu
 				if (acState.fanLevel)
 					rotationSpeed = fanLeveltoHK(acState.fanLevel, this.capabilities[acState.mode].fanLevels)
 				if (acState.targetTemperature)
-					targetTemperature = this.temperatureUnit === 'F' ? toCelsius(acState.targetTemperature) : acState.targetTemperature
+					targetTemperature = this.temperatureUnit === FAHRENHEIT_UNIT ? toCelsius(acState.targetTemperature) : acState.targetTemperature
 
 				// if mode is fan
 				if (acState.mode === 'fan' && !this.setProcessing) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-sensibo-ac",
   "description": "Homebridge plugin for Sensibo - Smart AC Control",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "repository": {
     "type": "git",
     "url": "git://github.com/nitaybz/homebridge-sensibo-ac.git"


### PR DESCRIPTION
Includes a couple Fahrenheit fixes based on testing:

1. Uses celsius for the upper/lower temperature thresholds (seems like homebridge/homekit always wants celsius for those too)
2. Reduces the `minStep` to 0.1, because of the conversion from celsius to Fahrenheit it wasn't allowing single degree increments in the Home app. @nitaybz I wasn't able to test this with celsius, but given that 0.1 is the default I think it should work well.
3. DRY'ed up some of the temperature conversion code with some helper methods. I think it makes it a little easier to pinpoint where celsius and Fahrenheit need to be converted. @nitaybz this stuff is optional, happy to remove if you want to keep things as-is.

<img width="281" alt="Screen Shot 2020-06-06 at 9 20 10 PM" src="https://user-images.githubusercontent.com/238023/83958064-89673280-a83b-11ea-8ce9-f61313d98e2b.png">
