### PR TITLE
Merge v2.5.1 back to Master - fix for #141

### DIFF
--- a/homekit/AirConditioner.js
+++ b/homekit/AirConditioner.js
@@ -462,7 +462,15 @@ class AirConditioner {
 	addLightSwitch() {
 		this.log.easyDebug(`${this.name} - Adding LightSwitchService`)
 
-		this.LightSwitchService = this.accessory.getService(this.roomName + 'AC Light')
+		// Required due to #141 - v2.5.0 changed LightSwitch service name, which caused conflicts, v2.5.1 restored previous naming
+		// TODO: plan for this to be removed in a future version
+		const LightSwitchFix = this.accessory.getService(this.roomName + 'AC Light')
+
+		if (LightSwitchFix) {
+			this.removeLightSwitchFix()
+		}
+
+		this.LightSwitchService = this.accessory.getService(this.roomName + ' AC Light')
 		if (!this.LightSwitchService) {
 			this.LightSwitchService = this.accessory.addService(Service.Lightbulb, this.roomName + 'AC Light', 'LightSwitch')
 		}
@@ -474,12 +482,23 @@ class AirConditioner {
 
 	removeLightSwitch() {
 		// Below || is required in case of name/type change of LightSwitch Service
-		const LightSwitch = this.accessory.getService('LightSwitch') || this.accessory.getService(this.roomName + 'AC Light')
+		const LightSwitch = this.accessory.getService('LightSwitch') || this.accessory.getService(this.roomName + ' AC Light')
 
 		if (LightSwitch) {
 			// remove service
 			this.log.easyDebug(`${this.name} - Removing LightSwitchService`)
 			this.accessory.removeService(LightSwitch)
+		}
+	}
+
+	removeLightSwitchFix() {
+		// Required due to #141 - v2.5.0 changed LightSwitch service name, which caused conflicts, v2.5.1 restored previous naming
+		const LightSwitchFix = this.accessory.getService(this.roomName + 'AC Light')
+
+		if (LightSwitchFix) {
+			// remove service
+			this.log.easyDebug(`${this.name} - Removing LightSwitchFixService`)
+			this.accessory.removeService(LightSwitchFix)
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-sensibo-ac",
-  "version": "2.5.0-alpha.3",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-sensibo-ac",
-      "version": "2.5.0-alpha.3",
+      "version": "2.5.1",
       "funding": [
         {
           "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Sensibo for Homebridge",
   "name": "homebridge-sensibo-ac",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Homebridge plugin for Sensibo - Smart AC Control",
   "license": "GNU",
   "repository": {


### PR DESCRIPTION
v2.5.1 (from release branch) has a fix for #141 this back merge is to keep master up to date before v2.6 changes are merged to prevent regression defects etc.

The fix for #141 that is included in v2.5.1 is to re-introduce the space in the AC LightSwitch service name, e.g.:

```javascript
this.roomName + 'AC Light' // was
this.roomName + ' AC Light' // will be
```

I have also added a check and clean-up function ```removeLightSwitchFix()``` to correct any AC LightSwitch services that got created with the 'wrong' name.