### PR TITLE
feat(climate-react): expose HomeKit AUTO via Climate React

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -164,6 +164,20 @@
                 "default": false,
                 "required": false
             },
+            "climateReactAutoAsAuto": {
+                "title": "Drive HomeKit AUTO via Climate React",
+                "description": "When enabled, the HomeKit AUTO mode is driven by Climate React (Smart mode) using the two AUTO setpoints as the low/high thresholds, instead of the AC's native AUTO. Requires Climate React to be set up in the Sensibo app.",
+                "type": "boolean",
+                "default": false,
+                "required": false
+            },
+            "climateReactAutoChangeover": {
+                "title": "AUTO full changeover (heat + cool)",
+                "description": "Only used when 'Drive HomeKit AUTO via Climate React' is enabled. When true the lower setpoint turns HEATING on (full heat/cool changeover); when false (default) the lower setpoint simply turns the unit off (cooling band).",
+                "type": "boolean",
+                "default": false,
+                "required": false
+            },
 			"enableHistoryStorage": {
 				"title": "Enable History Storage",
 				"description": "Record temperature & humidity measurements over time, viewable as History in the Eve app",

--- a/homekit/AirConditioner.js
+++ b/homekit/AirConditioner.js
@@ -43,6 +43,7 @@ class AirConditioner {
 		this.disableVerticalSwing = platform.disableVerticalSwing
 		this.disableLightSwitch = platform.disableLightSwitch
 		this.climateReactSwitchInAccessory = platform.climateReactSwitchInAccessory
+		this.climateReactAutoAsAuto = platform.climateReactAutoAsAuto
 		this.syncButtonInAccessory = platform.syncButtonInAccessory
 
 		this.capabilities = this.Utils.airConditionerCapabilities(device.remoteCapabilities.modes)
@@ -271,11 +272,14 @@ class AirConditioner {
 				} else if (mode === 'HEAT') {
 					this.addCharacteristicToService('HeaterCooler', 'HeatingThresholdTemperature', modeProps, true, true, null)
 				} else if (mode === 'AUTO') {
-					if (!this.capabilities.COOL || this.modesToExclude.includes('COOL')) {
+					// When driving AUTO via Climate React we need BOTH setpoints present to form the
+					// range, regardless of whether COOL/HEAT are also exposed. Otherwise keep the
+					// original behaviour of only adding a threshold that COOL/HEAT didn't already add.
+					if (this.climateReactAutoAsAuto || !this.capabilities.COOL || this.modesToExclude.includes('COOL')) {
 						this.addCharacteristicToService('HeaterCooler', 'CoolingThresholdTemperature', modeProps, true, true, null)
 					}
 
-					if (!this.capabilities.HEAT || this.modesToExclude.includes('HEAT')) {
+					if (this.climateReactAutoAsAuto || !this.capabilities.HEAT || this.modesToExclude.includes('HEAT')) {
 						this.addCharacteristicToService('HeaterCooler', 'HeatingThresholdTemperature', modeProps, true, true, null)
 					}
 				}

--- a/homekit/StateHandler.js
+++ b/homekit/StateHandler.js
@@ -2,22 +2,28 @@ function sensiboFormattedACState(device, state) {
 	device.log.easyDebug(`${device.name} -> sensiboFormattedACState start`)
 	// device.log.easyDebug(`${device.name} -> sensiboFormattedACState acState: ${JSON.stringify(acState, null, 4)}`)
 
+	// When driving HomeKit AUTO via Climate React, never send the AC's native "auto" mode
+	// (which keeps the fan running). Send a concrete "cool" command instead and let Climate
+	// React own the on/off cycling. Fall back to AUTO capabilities if COOL isn't available.
+	const sendAsCool = device.climateReactAutoAsAuto && state.mode === 'AUTO' && device.capabilities.COOL
+	const effectiveMode = sendAsCool ? 'COOL' : state.mode
+	const effectiveCaps = device.capabilities[effectiveMode]
 	const acState = {
 		on: state.active,
-		mode: state.mode.toLowerCase(),
+		mode: effectiveMode.toLowerCase(),
 		targetTemperature: device.usesFahrenheit ? device.Utils.toFahrenheit(state.targetTemperature) : state.targetTemperature,
 		temperatureUnit: device.temperatureUnit
 	}
-	const swingModes = device.Utils.sensiboFormattedSwingModes(device.capabilities[state.mode], state)
+	const swingModes = device.Utils.sensiboFormattedSwingModes(effectiveCaps, state)
 
 	// be mindful .assign() copies references (not a deep clone): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#examples
 	Object.assign(acState, swingModes)
 
-	if ('fanSpeeds' in device.capabilities[state.mode]) {
-		acState.fanLevel = device.Utils.percentToFanLevel(state.fanSpeed, device.capabilities[state.mode].fanSpeeds)
+	if ('fanSpeeds' in effectiveCaps) {
+		acState.fanLevel = device.Utils.percentToFanLevel(state.fanSpeed, effectiveCaps.fanSpeeds)
 	}
 
-	if ('light' in device.capabilities[state.mode]) {
+	if ('light' in effectiveCaps) {
 		acState.light = state.light ? 'on' : 'off'
 	}
 

--- a/homekit/StateManager.js
+++ b/homekit/StateManager.js
@@ -1,6 +1,7 @@
 let Characteristic
 let log
 let MINIMUM_NODE
+let platformRef
 
 function characteristicToMode(characteristic) {
 	// log.easyDebug(`characteristicToMode - characteristic: ${characteristic}`)
@@ -72,6 +73,31 @@ function updateClimateReact(device, enableClimateReactAutoSetup) {
 		smartModeState.highTemperatureState.on = false
 		smartModeState.lowTemperatureThreshold = device.state.targetTemperature - (device.usesFahrenheit ? 1.8 : 1)
 		smartModeState.lowTemperatureState.on = true
+	} else if (device.state.mode === 'AUTO' && platformRef?.climateReactAutoAsAuto) {
+		// HomeKit AUTO exposes two setpoints (a range). We map them directly onto Climate
+		// React's low/high thresholds so CR - not the AC's native AUTO - drives on/off cycling.
+		// The two setpoints live on the HeaterCooler characteristics, so read them from there.
+		const svc = device.HeaterCoolerService
+		const highSetpoint = svc.getCharacteristic(Characteristic.CoolingThresholdTemperature).value // top of the band
+		const lowSetpoint = svc.getCharacteristic(Characteristic.HeatingThresholdTemperature).value // bottom of the band
+		const changeover = !!platformRef?.climateReactAutoChangeover
+
+		// Upper edge: start cooling
+		smartModeState.highTemperatureThreshold = highSetpoint
+		smartModeState.highTemperatureState.on = true
+		smartModeState.highTemperatureState.mode = 'cool'
+		smartModeState.highTemperatureState.targetTemperature = highSetpoint
+
+		// Lower edge: either stop the unit (cooling band, default) or start heating (full changeover)
+		smartModeState.lowTemperatureThreshold = lowSetpoint
+		smartModeState.lowTemperatureState.on = changeover
+		smartModeState.lowTemperatureState.mode = changeover ? 'heat' : 'cool'
+		smartModeState.lowTemperatureState.targetTemperature = lowSetpoint
+
+		// In AUTO the plugin owns whether Climate React is on: enabled iff the accessory is active.
+		smartModeState.enabled = device.state.active
+
+		log.easyDebug(`${device.name} updateClimateReact (AUTO) - band [${lowSetpoint}, ${highSetpoint}], changeover: ${changeover}, enabled: ${smartModeState.enabled}`)
 	}
 
 	if ('fanSpeeds' in device.capabilities[device.state.mode] && 'fanSpeed' in device.state) {
@@ -112,8 +138,9 @@ export default (device, platform) => {
 	Characteristic = platform.api.hap.Characteristic
 	log = platform.log
 	MINIMUM_NODE = platform.MINIMUM_NODE
+	platformRef = platform
 
-	const enableClimateReactAutoSetup = platform.enableClimateReactAutoSetup
+	const enableClimateReactAutoSetup = platform.enableClimateReactAutoSetup || platform.climateReactAutoAsAuto
 
 	return {
 

--- a/index.js
+++ b/index.js
@@ -68,6 +68,8 @@ class SensiboACPlatform {
 		this.disableLightSwitch = config['disableLightSwitch'] || false
 		this.disableVerticalSwing = config['disableVerticalSwing'] || false
 		this.enableClimateReactAutoSetup = config['enableClimateReactAutoSetup'] || false
+		this.climateReactAutoAsAuto = config['climateReactAutoAsAuto'] || false
+		this.climateReactAutoChangeover = config['climateReactAutoChangeover'] || false
 		this.enableClimateReactSwitch = config['enableClimateReactSwitch'] || false
 		this.enableHistoryStorage = config['enableHistoryStorage'] || false
 		this.enableOccupancySensor = config['enableOccupancySensor'] || false


### PR DESCRIPTION
Adds an opt-in 'climateReactAutoAsAuto' mode: when enabled, the HomeKit AUTO thermostat mode is driven by Climate React (Smart mode) instead of the AC's native AUTO (which keeps the fan running continuously).

The two HomeKit AUTO setpoints (Heating/Cooling threshold) are mapped directly onto Climate React's low/high temperature thresholds, so CR handles the on/off cycling and the unit fully powers down between cycles.

- index.js: read climateReactAutoAsAuto + climateReactAutoChangeover config
- config.schema.json: expose both options in the Homebridge UI
- StateManager.js: AUTO branch in updateClimateReact mapping setpoints -> CR
- StateHandler.js: send 'cool' to the AC in AUTO (never native 'auto')
- AirConditioner.js: always add both threshold characteristics in AUTO

climateReactAutoChangeover=false (default) -> cooling band (low edge = off)
climateReactAutoChangeover=true            -> full heat/cool changeover