### PR TITLE
feat(climate-react): optionally back the HomeKit AUTO mode with Climate React

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Check with: `node -v` & `homebridge -V` and update if needed
 - **HeaterCooler** (Air Conditioner) control, including adjusting fan speed (Rotation Speed) & vertical swing (Oscillate) from within the accessory in the Apple Home app.
 - **AC Sync Button** - easily toggle the state of the AC between ON/OFF in case your AC is out of sync (does not send commands to the AC)
 - **Climate React** - enable/disable Climate React (Smart mode). To adjust the settings, use the Sensibo app or turn on `Climate React Auto Setup`
+- **Climate React as the AUTO mode** - optionally back the HomeKit AUTO mode with Climate React, so the AC switches fully off between cooling cycles instead of running its fan continuously. The AUTO temperature range sets the Climate React thresholds
 - **Occupancy Sensor** - show the Home/Away status from Sensibo in the Home app via Occupancy sensor
 - **History Storage** - store temperature and humidity measurements over time, review them in the Eve app as a graph
 
@@ -146,6 +147,14 @@ See below the table for additional details on these settings.
 | `enableClimateReactSwitch` |  Adds a switch to enable/disable Climate React (Smart mode)      |          |  `false` |  Boolean |
 | `climateReactSwitchInAccessory` |  When set to `true`, adds a **Climate React** switch (like `enableClimateReactSwitch` above) but within the AC accessory. It will also remove the standalone AC Climate React switch (if one exists). Works only when `enableClimateReactSwitch` is also set to true  |          |  `false` |  Boolean  |
 | `enableClimateReactAutoSetup` |  When set to `true`, will auto-update the Climate React (Smart mode) configuration to align whenever the AC state is set or changed  |          |  `false` |  Boolean  |
+| `climateReactAsAutoMode`   |  When set to `true`, the HomeKit AUTO mode is backed by Climate React instead of the AC's native AUTO. See [Climate React as the AUTO mode](#climate-react-as-the-auto-mode)  |          |  `false` |  Boolean  |
+| `climateReactAutoLowOffset` |  Offset added to the **low** threshold sent to Climate React (a HomeKit range of 23-24 becomes 23.2-24). The high threshold is never offset. Only used when `climateReactAsAutoMode` is enabled  |          |  `0.2` |  Number  |
+| `climateReactAutoTargetTemperature` |  The AC setpoint Climate React commands when it switches the unit on in AUTO. Clamped to what the AC supports. Only used when `climateReactAsAutoMode` is enabled  |          |  `22` |  Integer  |
+| `climateReactAutoFanLevel` |  The fan level Climate React commands when it switches the unit on in AUTO. Falls back to the current fan level if unsupported by the AC. Only used when `climateReactAsAutoMode` is enabled  |          |  `low` |  String  |
+| `climateReactAutoTemperatureStep` |  Step for the HomeKit AUTO range. `0.5` allows ranges like 23.5-24.5, since Climate React thresholds are triggers rather than AC setpoints. Commands sent to the AC are still rounded to a whole degree. Celsius only. Only used when `climateReactAsAutoMode` is enabled  |          |  `1` |  Number  |
+| `climateReactAutoMinTemperature` |  Narrows the bottom of the temperature slider in the Home app. Ignored if lower than the AC supports. Only used when `climateReactAsAutoMode` is enabled  |          |  -  |  Number  |
+| `climateReactAutoMaxTemperature` |  Narrows the top of the temperature slider in the Home app. Ignored if higher than the AC supports. Only used when `climateReactAsAutoMode` is enabled  |          |  -  |  Number  |
+| `climateReactAutoDebounceMs` |  How long to wait after the last change before sending the Climate React update, so dragging the AUTO range results in a single API call. Only used when `climateReactAsAutoMode` is enabled  |          |  `3000` |  Integer  |
 | `enableHistoryStorage`     |  When set to `true`, temperature & humidity measurements will be stored over time, viewable as History in the Eve app  |          |  `false` |   Boolean |
 | `enableOccupancySensor`    |  Adds an occupancy sensor to represent the state of someone at home  |          |  `false` |  Boolean  |
 | `enableSyncButton`         |  When set to `true`, adds an **AC Sync** switch to toggle the state of the accessory in the Home app, without sending a command to the unit  |          |  `false` |  Boolean  |
@@ -258,6 +267,83 @@ To enable **Climate React Auto Setup**, add `"enableClimateReactAutoSetup": true
 Note: only temperature thresholds are supported by Climate React auto setup, for full options, see "Climate React" in the Sensibo app.
 
 Note 2: currently this does not work on Dry or Fan modes (as these are treated as separate accessories).
+
+#### Climate React as the AUTO mode
+
+Most ACs have a native AUTO mode, but it usually only modulates the compressor and keeps the fan running the
+whole time. Climate React does what AUTO is generally expected to do - it switches the unit **fully off** once
+the room is cool enough and back on when it warms up again - but by default it is only reachable as a separate
+switch.
+
+With `"climateReactAsAutoMode": true`, the HomeKit AUTO mode is backed by Climate React:
+
+- **COOL** is unchanged: it commands the AC directly with the temperature you set.
+- **AUTO** sends **no command to the AC**. Selecting it enables Climate React, which alone switches the unit
+  on and off. The AUTO temperature range in the Home app sets the Climate React thresholds.
+- Switching from AUTO to **COOL** or turning the accessory **off** disables Climate React.
+
+##### The temperature range
+
+The two thumbs of the HomeKit AUTO range map onto the Climate React thresholds:
+
+| HomeKit AUTO range | Climate React | Behaviour |
+| ------------------ | ------------- | --------- |
+| Upper value (e.g. 24°) | `highTemperatureThreshold` = 24 | Above this, the unit is switched **on** |
+| Lower value (e.g. 23°) | `lowTemperatureThreshold` = 23.2 | Below this, the unit is switched **off** |
+
+The low threshold is nudged up by `climateReactAutoLowOffset` (0.2 by default), so a HomeKit range of 23-24
+becomes 23.2-24 in Climate React. The high threshold is never offset.
+
+##### How hard it cools
+
+The range decides *when* the AC runs; two separate settings decide how it runs once Climate React switches it
+on:
+
+- `climateReactAutoTargetTemperature` (default `22`) - the setpoint commanded on the AC
+- `climateReactAutoFanLevel` (default `low`) - the fan level commanded on the AC
+
+Both are validated against the AC's reported capabilities and fall back to a supported value if necessary.
+
+##### Range step and bounds
+
+By default the AUTO range steps in whole degrees and spans everything the AC reports as supported, which is
+often wider than useful. Climate React thresholds are triggers rather than AC setpoints, so they can be finer:
+
+- `climateReactAutoTemperatureStep: 0.5` allows ranges like 23.5-24.5. Commands sent to the AC itself are
+  still rounded to a whole degree, so nothing invalid reaches the API. Celsius only.
+- `climateReactAutoMinTemperature` / `climateReactAutoMaxTemperature` narrow the slider, for example to
+  18-28. Values outside the AC's own capabilities are ignored.
+
+Bear in mind that a narrower band means the AC cycles more often.
+
+##### Example config
+
+```json
+{
+    "platform": "SensiboAC",
+    "apiKey": "YOUR_API_KEY",
+    "climateReactAsAutoMode": true,
+    "climateReactAutoLowOffset": 0.2,
+    "climateReactAutoTargetTemperature": 22,
+    "climateReactAutoFanLevel": "low",
+    "climateReactAutoTemperatureStep": 0.5,
+    "climateReactAutoMinTemperature": 18,
+    "climateReactAutoMaxTemperature": 28,
+    "modesToExclude": ["HEAT", "DRY", "FAN"]
+}
+```
+
+##### Notes
+
+- Set up Climate React once in the Sensibo app before enabling this - the plugin updates the existing
+  configuration rather than creating one from scratch.
+- Keep both `COOL` and `AUTO` available (exclude `HEAT` if your AC does not heat). This is what makes the Home
+  app expose both thumbs of the AUTO range.
+- The Climate React switch (`enableClimateReactSwitch`) duplicates this control and is best left off.
+- Because state is polled roughly every 90 seconds, the cooling/idle indication in the Home app can lag behind
+  reality by up to one polling cycle.
+- Only cooling is currently supported - the low edge switches the unit off rather than heating. Heat/cool
+  changeover could be added later using Climate React's low temperature state.
 
 ### Filter cleaning indication
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -171,6 +171,29 @@
                 "default": 0.2,
                 "required": false
             },
+            "climateReactAutoTargetTemperature": {
+                "title": "AUTO: AC setpoint while cooling (°C)",
+                "description": "The temperature Climate React commands on the AC when it switches the unit on in AUTO. Independent of the AUTO range: the range decides when the AC runs, this decides how hard it cools. Clamped to what the AC supports. Default 22.",
+                "type": "integer",
+                "default": 22,
+                "required": false
+            },
+            "climateReactAutoFanLevel": {
+                "title": "AUTO: fan level while cooling",
+                "description": "The fan level Climate React commands on the AC when it switches the unit on in AUTO. Falls back to the current fan level if the AC doesn't support the chosen one. Default low.",
+                "type": "string",
+                "default": "low",
+                "oneOf": [
+                    { "title": "Low", "enum": ["low"] },
+                    { "title": "Medium low", "enum": ["medium_low"] },
+                    { "title": "Medium", "enum": ["medium"] },
+                    { "title": "Medium high", "enum": ["medium_high"] },
+                    { "title": "High", "enum": ["high"] },
+                    { "title": "Strong", "enum": ["strong"] },
+                    { "title": "Auto", "enum": ["auto"] }
+                ],
+                "required": false
+            },
             "climateReactAutoDebounceMs": {
                 "title": "Climate React update debounce (ms)",
                 "description": "How long to wait after the last change before sending the Climate React update. Coalesces the burst of updates HomeKit sends when dragging the AUTO range, avoiding rate-limit (429) errors. Default 3000.",

--- a/config.schema.json
+++ b/config.schema.json
@@ -205,6 +205,18 @@
                 ],
                 "required": false
             },
+            "climateReactAutoMinTemperature": {
+                "title": "AUTO: minimum selectable temperature (°C)",
+                "description": "Narrows the bottom of the temperature slider in the Home app, so you don't have to drag through temperatures you'd never use. Ignored if lower than what the AC supports. Only used when 'climateReactAsAutoMode' is enabled.",
+                "type": "number",
+                "required": false
+            },
+            "climateReactAutoMaxTemperature": {
+                "title": "AUTO: maximum selectable temperature (°C)",
+                "description": "Narrows the top of the temperature slider in the Home app. Ignored if higher than what the AC supports. Only used when 'climateReactAsAutoMode' is enabled.",
+                "type": "number",
+                "required": false
+            },
             "climateReactAutoDebounceMs": {
                 "title": "Climate React update debounce (ms)",
                 "description": "How long to wait after the last change before sending the Climate React update. Coalesces the burst of updates HomeKit sends when dragging the AUTO range, avoiding rate-limit (429) errors. Default 3000.",

--- a/config.schema.json
+++ b/config.schema.json
@@ -194,6 +194,17 @@
                 ],
                 "required": false
             },
+            "climateReactAutoTemperatureStep": {
+                "title": "AUTO: temperature range step (°C)",
+                "description": "Step for the HomeKit AUTO range. Climate React thresholds are triggers rather than AC setpoints, so they can be finer than the whole degrees the AC accepts - 0.5 allows ranges like 23.5-24.5. Commands sent to the AC itself are still rounded to a whole degree. Celsius only. Default 1.",
+                "type": "number",
+                "default": 1,
+                "oneOf": [
+                    { "title": "1.0°", "enum": [1] },
+                    { "title": "0.5°", "enum": [0.5] }
+                ],
+                "required": false
+            },
             "climateReactAutoDebounceMs": {
                 "title": "Climate React update debounce (ms)",
                 "description": "How long to wait after the last change before sending the Climate React update. Coalesces the burst of updates HomeKit sends when dragging the AUTO range, avoiding rate-limit (429) errors. Default 3000.",

--- a/config.schema.json
+++ b/config.schema.json
@@ -157,6 +157,28 @@
                 "default": false,
                 "required": false
             },
+            "climateReactAsAutoMode": {
+                "title": "Use Climate React as the AUTO mode",
+                "description": "Back the HomeKit AUTO mode with Climate React (Smart mode) instead of the AC's native AUTO. In AUTO nothing is sent to the AC - Climate React alone switches it on/off, so the fan stops between cycles. The AUTO temperature range sets the Climate React low/high thresholds. Switching to COOL or OFF disables Climate React. Exclude HEAT from the modes when using this.",
+                "type": "boolean",
+                "default": false,
+                "required": false
+            },
+            "climateReactAutoLowOffset": {
+                "title": "AUTO low threshold offset (°C)",
+                "description": "Added to the LOW threshold sent to Climate React only, so HomeKit 23 becomes 23.2 in Climate React. The high threshold is never offset. Default 0.2.",
+                "type": "number",
+                "default": 0.2,
+                "required": false
+            },
+            "climateReactAutoDebounceMs": {
+                "title": "Climate React update debounce (ms)",
+                "description": "How long to wait after the last change before sending the Climate React update. Coalesces the burst of updates HomeKit sends when dragging the AUTO range, avoiding rate-limit (429) errors. Default 3000.",
+                "type": "integer",
+                "default": 3000,
+                "minimum": 0,
+                "required": false
+            },
             "enableClimateReactAutoSetup": {
                 "title": "Enable Climate React Auto Setup",
                 "description": "Auto-update the Climate React (Smart mode) configuration to align whenever the AC state is set or changed",

--- a/homekit/AirConditioner.js
+++ b/homekit/AirConditioner.js
@@ -719,7 +719,11 @@ class AirConditioner {
 						this.Utils.updateValue('HeaterCoolerService', 'CurrentHeaterCoolerState', Characteristic.CurrentHeaterCoolerState.HEATING)
 					} else if (this.state.mode === 'AUTO') {
 						this.Utils.updateValue('HeaterCoolerService', 'TargetHeaterCoolerState', Characteristic.TargetHeaterCoolerState.AUTO)
-						if (this.state.currentTemperature > this.state.targetTemperature) {
+						if (this.climateReactAsAutoMode) {
+							// Climate React drives AUTO: COOLING while it has the unit running, IDLE while it
+							// waits for the room to warm back up to the top of the band.
+							this.Utils.updateValue('HeaterCoolerService', 'CurrentHeaterCoolerState', this.acPowerOn ? Characteristic.CurrentHeaterCoolerState.COOLING : Characteristic.CurrentHeaterCoolerState.IDLE)
+						} else if (this.state.currentTemperature > this.state.targetTemperature) {
 							this.Utils.updateValue('HeaterCoolerService', 'CurrentHeaterCoolerState', Characteristic.CurrentHeaterCoolerState.COOLING)
 						} else {
 							this.Utils.updateValue('HeaterCoolerService', 'CurrentHeaterCoolerState', Characteristic.CurrentHeaterCoolerState.HEATING)

--- a/homekit/AirConditioner.js
+++ b/homekit/AirConditioner.js
@@ -48,6 +48,13 @@ class AirConditioner {
 		this.climateReactAsAutoMode = platform.climateReactAsAutoMode
 		this.climateReactAutoLowOffset = platform.climateReactAutoLowOffset
 
+		// Climate React thresholds are triggers rather than AC setpoints, so the AUTO range can be finer
+		// than the whole degrees the AC accepts. Commands sent to the AC itself are rounded back to a
+		// supported value (see sensiboFormattedACState).
+		if (this.climateReactAsAutoMode && this.temperatureUnit !== FAHRENHEIT_UNIT) {
+			this.temperatureStep = platform.climateReactAutoTemperatureStep ?? 1
+		}
+
 		this.capabilities = this.Utils.airConditionerCapabilities(device.remoteCapabilities.modes)
 
 		// climateReactAsAutoMode: the HomeKit AUTO range lives here, not in state.targetTemperature

--- a/homekit/AirConditioner.js
+++ b/homekit/AirConditioner.js
@@ -55,6 +55,9 @@ class AirConditioner {
 			this.temperatureStep = platform.climateReactAutoTemperatureStep ?? 1
 		}
 
+		this.climateReactAutoMinTemperature = platform.climateReactAutoMinTemperature
+		this.climateReactAutoMaxTemperature = platform.climateReactAutoMaxTemperature
+
 		this.capabilities = this.Utils.airConditionerCapabilities(device.remoteCapabilities.modes)
 
 		// climateReactAsAutoMode: the HomeKit AUTO range lives here, not in state.targetTemperature
@@ -282,6 +285,19 @@ class AirConditioner {
 						maxValue: this.Utils.toCelsius(this.capabilities[mode].temperatures[FAHRENHEIT_UNIT].max),
 						minStep: this.temperatureStep
 					}
+				}
+			}
+
+			// Optionally narrow the temperature slider. modeProps is only used for the threshold
+			// characteristics, so this affects the range shown in the Home app and nothing else. Values
+			// outside the AC's own capabilities are ignored, since the AC would reject them anyway.
+			if (modeProps && this.climateReactAsAutoMode) {
+				if (this.climateReactAutoMinTemperature !== null && this.climateReactAutoMinTemperature > modeProps.minValue) {
+					modeProps.minValue = this.climateReactAutoMinTemperature
+				}
+
+				if (this.climateReactAutoMaxTemperature !== null && this.climateReactAutoMaxTemperature < modeProps.maxValue) {
+					modeProps.maxValue = this.climateReactAutoMaxTemperature
 				}
 			}
 

--- a/homekit/AirConditioner.js
+++ b/homekit/AirConditioner.js
@@ -55,6 +55,7 @@ class AirConditioner {
 			this.temperatureStep = platform.climateReactAutoTemperatureStep ?? 1
 		}
 
+		this.climateReactAutoFanLevel = platform.climateReactAutoFanLevel
 		this.climateReactAutoMinTemperature = platform.climateReactAutoMinTemperature
 		this.climateReactAutoMaxTemperature = platform.climateReactAutoMaxTemperature
 

--- a/homekit/AirConditioner.js
+++ b/homekit/AirConditioner.js
@@ -45,7 +45,20 @@ class AirConditioner {
 		this.climateReactSwitchInAccessory = platform.climateReactSwitchInAccessory
 		this.syncButtonInAccessory = platform.syncButtonInAccessory
 
+		this.climateReactAsAutoMode = platform.climateReactAsAutoMode
+		this.climateReactAutoLowOffset = platform.climateReactAutoLowOffset
+
 		this.capabilities = this.Utils.airConditionerCapabilities(device.remoteCapabilities.modes)
+
+		// climateReactAsAutoMode: the HomeKit AUTO range lives here, not in state.targetTemperature
+		// (a single value shared by both range thumbs). `pending` means the user just moved a thumb and
+		// a Climate React update is in flight, so a background refresh must not overwrite the band yet.
+		this.autoBand = {
+			low: null,
+			high: null,
+			pending: false
+		}
+		this.Utils.syncAutoBandFromDevice(device)
 
 		this.state = this.cachedState.devices[this.id] = this.Utils.airConditionerStateFromDevice(device)
 		this.state = new Proxy(this.state, StateHandler(this, platform))
@@ -671,8 +684,15 @@ class AirConditioner {
 					this.Utils.updateValue('HeaterCoolerService', 'Active', 1)
 
 					// update temperatures for HeaterCoolerService
-					this.Utils.updateValue('HeaterCoolerService', 'HeatingThresholdTemperature', this.state.targetTemperature)
-					this.Utils.updateValue('HeaterCoolerService', 'CoolingThresholdTemperature', this.state.targetTemperature)
+					if (this.climateReactAsAutoMode && this.state.mode === 'AUTO' && this.autoBand.low !== null && this.autoBand.high !== null) {
+						// AUTO is a range: push the two band edges separately, otherwise both thumbs would
+						// get the same value and the range would collapse.
+						this.Utils.updateValue('HeaterCoolerService', 'HeatingThresholdTemperature', this.autoBand.low)
+						this.Utils.updateValue('HeaterCoolerService', 'CoolingThresholdTemperature', this.autoBand.high)
+					} else {
+						this.Utils.updateValue('HeaterCoolerService', 'HeatingThresholdTemperature', this.state.targetTemperature)
+						this.Utils.updateValue('HeaterCoolerService', 'CoolingThresholdTemperature', this.state.targetTemperature)
+					}
 
 					// update vertical swing for HeaterCoolerService
 					if (!this.disableVerticalSwing && this.capabilities[this.state.mode].VerticalSwing) {

--- a/homekit/StateHandler.js
+++ b/homekit/StateHandler.js
@@ -265,13 +265,14 @@ export default (device, platform) => {
 
 			// Send Climate React state command and refresh state
 			if (prop === 'smartMode') {
+				// Build the payload NOW rather than when the debounce fires. A refreshState landing during
+				// the debounce window overwrites state.smartMode with what Sensibo still has stored, so
+				// reading it later would send the previous band back and undo the change being made.
+				const sensiboNewClimateReactState = sensiboFormattedClimateReactState(device, state)
+
 				clearTimeout(climateReactTimer)
 				climateReactTimer = setTimeout(async () => {
 					try {
-						// FIXME: check if sensiboFormattedClimateReactState is still required, could potentially be replaced with:
-						//        const sensiboNewClimateReactState = state.smartMode (or similar)??
-						const sensiboNewClimateReactState = sensiboFormattedClimateReactState(device, state)
-
 						log.easyDebug(`${device.name} - StateHandler smartMode - (debounced ${climateReactDebounceMs}ms) before calling API to set new Climate React`)
 						log.easyDebug(`${device.name} - StateHandler smartMode - payload: ${JSON.stringify(sensiboNewClimateReactState)}`)
 

--- a/homekit/StateHandler.js
+++ b/homekit/StateHandler.js
@@ -2,24 +2,37 @@ function sensiboFormattedACState(device, state) {
 	device.log.easyDebug(`${device.name} -> sensiboFormattedACState start`)
 	// device.log.easyDebug(`${device.name} -> sensiboFormattedACState acState: ${JSON.stringify(acState, null, 4)}`)
 
+	// climateReactAsAutoMode: while in AUTO we normally send nothing to the AC, but turning the accessory
+	// off still has to reach it. Never send the AC's native "auto" in that command - it is exactly the mode
+	// this feature exists to avoid (its fan never stops), and it would linger in the AC's state until
+	// Climate React next fires. Send "cool" instead, which is what Climate React itself commands.
+	const drivenByClimateReact = device.climateReactAsAutoMode && state.mode === 'AUTO'
+	const effectiveMode = drivenByClimateReact ? 'COOL' : state.mode
+	const effectiveCapabilities = device.capabilities[effectiveMode] ?? device.capabilities[state.mode]
 	const acState = {
 		on: state.active,
-		mode: state.mode.toLowerCase(),
+		mode: effectiveMode.toLowerCase(),
 		// The AUTO range may use a finer step than the AC supports (Climate React thresholds are triggers,
 		// not setpoints), so round back to a whole degree here - Sensibo rejects fractional setpoints with 400.
 		targetTemperature: device.usesFahrenheit ? device.Utils.toFahrenheit(state.targetTemperature) : Math.round(state.targetTemperature),
 		temperatureUnit: device.temperatureUnit
 	}
-	const swingModes = device.Utils.sensiboFormattedSwingModes(device.capabilities[state.mode], state)
+	const swingModes = device.Utils.sensiboFormattedSwingModes(effectiveCapabilities, state)
 
 	// be mindful .assign() copies references (not a deep clone): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#examples
 	Object.assign(acState, swingModes)
 
-	if ('fanSpeeds' in device.capabilities[state.mode]) {
-		acState.fanLevel = device.Utils.percentToFanLevel(state.fanSpeed, device.capabilities[state.mode].fanSpeeds)
+	if ('fanSpeeds' in effectiveCapabilities) {
+		// In AUTO, keep the fan level consistent with what Climate React commands, so the AC's stored state
+		// doesn't end up on "auto" (which is what the native AUTO mode uses).
+		const autoModeFanLevel = device.climateReactAutoFanLevel ?? 'low'
+
+		acState.fanLevel = drivenByClimateReact && effectiveCapabilities.fanSpeeds.includes(autoModeFanLevel)
+			? autoModeFanLevel
+			: device.Utils.percentToFanLevel(state.fanSpeed, effectiveCapabilities.fanSpeeds)
 	}
 
-	if ('light' in device.capabilities[state.mode]) {
+	if ('light' in effectiveCapabilities) {
 		acState.light = state.light ? 'on' : 'off'
 	}
 

--- a/homekit/StateHandler.js
+++ b/homekit/StateHandler.js
@@ -5,7 +5,9 @@ function sensiboFormattedACState(device, state) {
 	const acState = {
 		on: state.active,
 		mode: state.mode.toLowerCase(),
-		targetTemperature: device.usesFahrenheit ? device.Utils.toFahrenheit(state.targetTemperature) : state.targetTemperature,
+		// The AUTO range may use a finer step than the AC supports (Climate React thresholds are triggers,
+		// not setpoints), so round back to a whole degree here - Sensibo rejects fractional setpoints with 400.
+		targetTemperature: device.usesFahrenheit ? device.Utils.toFahrenheit(state.targetTemperature) : Math.round(state.targetTemperature),
 		temperatureUnit: device.temperatureUnit
 	}
 	const swingModes = device.Utils.sensiboFormattedSwingModes(device.capabilities[state.mode], state)

--- a/homekit/StateHandler.js
+++ b/homekit/StateHandler.js
@@ -126,6 +126,10 @@ export default (device, platform) => {
 	const setTimeoutDelay = 1000
 	let setTimer = null
 	let preventTurningOff = false
+	// climateReactAsAutoMode: one HomeKit range change fires several SETs (both thumbs + mode + active).
+	// Each used to POST /smartmode immediately, which Sensibo rate-limits with HTTP 429 - coalesce them.
+	const climateReactDebounceMs = platform.climateReactAutoDebounceMs ?? 3000
+	let climateReactTimer = null
 	const sensiboApi = platform.sensiboApi
 	const log = platform.log
 
@@ -246,13 +250,15 @@ export default (device, platform) => {
 
 			// Send Climate React state command and refresh state
 			if (prop === 'smartMode') {
-				(async () => {
+				clearTimeout(climateReactTimer)
+				climateReactTimer = setTimeout(async () => {
 					try {
 						// FIXME: check if sensiboFormattedClimateReactState is still required, could potentially be replaced with:
 						//        const sensiboNewClimateReactState = state.smartMode (or similar)??
 						const sensiboNewClimateReactState = sensiboFormattedClimateReactState(device, state)
 
-						log.easyDebug(`${device.name} - StateHandler smartMode - before calling API to set new Climate React`)
+						log.easyDebug(`${device.name} - StateHandler smartMode - (debounced ${climateReactDebounceMs}ms) before calling API to set new Climate React`)
+						log.easyDebug(`${device.name} - StateHandler smartMode - payload: ${JSON.stringify(sensiboNewClimateReactState)}`)
 
 						await sensiboApi.setDeviceClimateReactState(device.id, sensiboNewClimateReactState)
 					} catch (error) {
@@ -274,7 +280,12 @@ export default (device, platform) => {
 
 					log.easyDebug(`${device.name} - StateHandler - smartMode update complete, deleting state.smartMode.updateRunning`)
 					delete state.smartMode.updateRunning
-				})()
+
+					// The band has reached Sensibo, so a refresh may mirror it back into autoBand again.
+					if (device.autoBand) {
+						device.autoBand.pending = false
+					}
+				}, climateReactDebounceMs)
 
 				// TODO: should we "catch" if the API call fails and prevent it from updating state?
 
@@ -304,6 +315,15 @@ export default (device, platform) => {
 				} else {
 					log.easyDebug(`${device.name} - StateHandler pureBoost SET - skipping refreshState as platform.refreshStateProcessing: ${platform.refreshStateProcessing} OR platform.setProcessing: ${platform.setProcessing} is true.`)
 				}
+
+				return true
+			}
+
+			// climateReactAsAutoMode: AUTO sends NOTHING to the AC - Climate React alone switches the unit
+			// on and off, which is the whole point (the fan stops instead of running continuously).
+			// Turning the accessory OFF is still forwarded, so the unit actually stops.
+			if (platform.climateReactAsAutoMode && state.mode === 'AUTO' && state.active === true) {
+				log.easyDebug(`${device.name} - StateHandler - AUTO is driven by Climate React, skipping acState command for prop: ${prop}`)
 
 				return true
 			}

--- a/homekit/StateManager.js
+++ b/homekit/StateManager.js
@@ -225,6 +225,10 @@ function updateClimateReactAutoMode(device) {
 
 	log.easyDebug(`${device.name} - climateReactAsAutoMode - AUTO band: HomeKit [${low}, ${high}] -> Climate React [${lowThreshold}, ${high}], AC setpoint when running: ${acTargetTemperature}`)
 
+	// Mark the update as in flight, so a refresh landing while Sensibo rewrites the Climate React record
+	// doesn't mistake a transient "enabled: false" for the user leaving AUTO. Cleared once the POST lands.
+	device.autoBand.pending = true
+
 	// Assigning the whole object is what triggers StateHandler's setter (and the API call).
 	device.state.smartMode = smartModeState
 }

--- a/homekit/StateManager.js
+++ b/homekit/StateManager.js
@@ -148,7 +148,7 @@ function updateClimateReactAutoMode(device) {
 		return
 	}
 
-	const step = device.usesFahrenheit ? 1.8 : 1
+	const step = device.usesFahrenheit ? 1.8 : (platformRef.climateReactAutoTemperatureStep ?? 1)
 	const offset = platformRef.climateReactAutoLowOffset ?? 0.2
 	const high = device.autoBand.high
 	let low = device.autoBand.low

--- a/homekit/StateManager.js
+++ b/homekit/StateManager.js
@@ -252,6 +252,11 @@ export default (device, platform) => {
 
 				if (!active || stateCurrentMode === 'FAN' || stateCurrentMode === 'DRY') {
 					callback(null, Characteristic.CurrentHeaterCoolerState.INACTIVE)
+				} else if (platform.climateReactAsAutoMode && stateCurrentMode === 'AUTO') {
+					// climateReactAsAutoMode: AUTO stays active the whole time, but Climate React cycles the
+					// unit. Report what it is actually doing: cooling, or idling until the room warms back
+					// up to the top of the band.
+					callback(null, device.acPowerOn ? Characteristic.CurrentHeaterCoolerState.COOLING : Characteristic.CurrentHeaterCoolerState.IDLE)
 				} else if (stateCurrentMode === 'COOL') {
 					callback(null, Characteristic.CurrentHeaterCoolerState.COOLING)
 				} else if (stateCurrentMode === 'HEAT') {

--- a/homekit/StateManager.js
+++ b/homekit/StateManager.js
@@ -160,18 +160,28 @@ function updateClimateReactAutoMode(device) {
 	}
 
 	const lowThreshold = Math.round((low + offset) * 100) / 100
+	const coolCapabilities = device.capabilities.COOL ?? device.capabilities.AUTO
+	// The setpoint Climate React commands when it switches the unit on. Independent of the band: the
+	// band decides WHEN the AC runs, this decides how hard it cools while it does. Clamped to what the
+	// AC actually accepts, because Sensibo rejects out-of-range setpoints with HTTP 400.
+	let acTargetTemperature = platformRef.climateReactAutoTargetTemperature ?? 22
+	const temperatureRange = coolCapabilities?.temperatures?.[device.usesFahrenheit ? 'F' : 'C']
+
+	if (temperatureRange) {
+		acTargetTemperature = Math.min(Math.max(acTargetTemperature, temperatureRange.min), temperatureRange.max)
+	}
 
 	smartModeState.enabled = true
 	smartModeState.type = 'temperature'
 	smartModeState.highTemperatureWebhook = null
 	smartModeState.lowTemperatureWebhook = null
 
-	// Upper edge: start cooling to the top of the band.
+	// Upper edge: switch the unit on and cool at the configured setpoint.
 	smartModeState.highTemperatureThreshold = high
 	smartModeState.highTemperatureState = {
 		on: true,
 		mode: 'cool',
-		targetTemperature: high,
+		targetTemperature: acTargetTemperature,
 		temperatureUnit: device.temperatureUnit
 	}
 
@@ -180,13 +190,19 @@ function updateClimateReactAutoMode(device) {
 	smartModeState.lowTemperatureState = {
 		on: false,
 		mode: 'cool',
-		targetTemperature: low,
+		targetTemperature: acTargetTemperature,
 		temperatureUnit: device.temperatureUnit
 	}
 
-	const coolCapabilities = device.capabilities.COOL ?? device.capabilities.AUTO
+	const configuredFanLevel = platformRef.climateReactAutoFanLevel ?? 'low'
 
-	if (coolCapabilities && 'fanSpeeds' in coolCapabilities && 'fanSpeed' in device.state) {
+	if (coolCapabilities && 'fanSpeeds' in coolCapabilities && coolCapabilities.fanSpeeds.includes(configuredFanLevel)) {
+		smartModeState.highTemperatureState.fanLevel = configuredFanLevel
+		smartModeState.lowTemperatureState.fanLevel = configuredFanLevel
+	} else if (coolCapabilities && 'fanSpeeds' in coolCapabilities && 'fanSpeed' in device.state) {
+		// Configured fan level isn't supported by this AC - fall back to whatever is currently set.
+		log.easyDebug(`${device.name} - climateReactAsAutoMode - fan level '${configuredFanLevel}' not supported, using current`)
+
 		const currentFanLevel = device.Utils.percentToFanLevel(device.state.fanSpeed, coolCapabilities.fanSpeeds)
 
 		smartModeState.highTemperatureState.fanLevel = currentFanLevel
@@ -207,7 +223,7 @@ function updateClimateReactAutoMode(device) {
 		Object.assign(smartModeState.lowTemperatureState, swingModes)
 	}
 
-	log.easyDebug(`${device.name} - climateReactAsAutoMode - AUTO band: HomeKit [${low}, ${high}] -> Climate React [${lowThreshold}, ${high}]`)
+	log.easyDebug(`${device.name} - climateReactAsAutoMode - AUTO band: HomeKit [${low}, ${high}] -> Climate React [${lowThreshold}, ${high}], AC setpoint when running: ${acTargetTemperature}`)
 
 	// Assigning the whole object is what triggers StateHandler's setter (and the API call).
 	device.state.smartMode = smartModeState

--- a/homekit/StateManager.js
+++ b/homekit/StateManager.js
@@ -1,6 +1,7 @@
 let Characteristic
 let log
 let MINIMUM_NODE
+let platformRef
 
 function characteristicToMode(characteristic) {
 	// log.easyDebug(`characteristicToMode - characteristic: ${characteristic}`)
@@ -108,10 +109,115 @@ function updateClimateReact(device, enableClimateReactAutoSetup) {
 	device.state.smartMode = smartModeState
 }
 
+/**
+ * climateReactAsAutoMode: back the HomeKit AUTO mode with Climate React (Sensibo "Smart mode").
+ *
+ * Design notes (learned the hard way):
+ *  - In AUTO we send NOTHING to the AC. Climate React alone switches the unit on/off, so the AC's
+ *    fan actually stops between cycles. StateHandler skips the acState POST while in AUTO.
+ *  - The single source of truth for "HomeKit is in AUTO" is smartMode.enabled as reported by
+ *    Sensibo (see Utils.airConditionerStateFromDevice). Because we never push a mode to the AC,
+ *    acState.mode can't fight the HomeKit tile.
+ *  - The band lives in device.autoBand (NOT state.targetTemperature, which is a single value and
+ *    would collapse the two range thumbs onto each other).
+ *  - The low offset is applied ONLY to lowTemperatureThreshold (a trigger, may be fractional).
+ *    lowTemperatureState.targetTemperature must stay a whole setpoint from the AC's list -
+ *    Sensibo rejects fractional AC setpoints with HTTP 400.
+ *
+ * @param   {Object}  device  Accessory whose Climate React state should be re-derived
+ * @returns {void}
+ */
+function updateClimateReactAutoMode(device) {
+	if (!platformRef?.climateReactAsAutoMode || !device.autoBand) {
+		return
+	}
+
+	const smartModeState = device.state.smartMode
+	const inAuto = device.state.mode === 'AUTO' && device.state.active === true
+
+	// Leaving AUTO (to COOL / HEAT / OFF) must switch Climate React off.
+	if (!inAuto) {
+		if (!smartModeState.enabled) {
+			return
+		}
+
+		log.easyDebug(`${device.name} - climateReactAsAutoMode - left AUTO (mode: ${device.state.mode}, active: ${device.state.active}), disabling Climate React`)
+		smartModeState.enabled = false
+		device.state.smartMode = smartModeState
+
+		return
+	}
+
+	const step = device.usesFahrenheit ? 1.8 : 1
+	const offset = platformRef.climateReactAutoLowOffset ?? 0.2
+	const high = device.autoBand.high
+	let low = device.autoBand.low
+
+	// HomeKit can momentarily collapse both range thumbs onto the same value while dragging;
+	// a degenerate band would make Climate React switch on and off at one threshold.
+	if (!(low < high)) {
+		low = high - step
+	}
+
+	const lowThreshold = Math.round((low + offset) * 100) / 100
+
+	smartModeState.enabled = true
+	smartModeState.type = 'temperature'
+	smartModeState.highTemperatureWebhook = null
+	smartModeState.lowTemperatureWebhook = null
+
+	// Upper edge: start cooling to the top of the band.
+	smartModeState.highTemperatureThreshold = high
+	smartModeState.highTemperatureState = {
+		on: true,
+		mode: 'cool',
+		targetTemperature: high,
+		temperatureUnit: device.temperatureUnit
+	}
+
+	// Lower edge: switch the unit off entirely (that's the whole point - the fan stops too).
+	smartModeState.lowTemperatureThreshold = lowThreshold
+	smartModeState.lowTemperatureState = {
+		on: false,
+		mode: 'cool',
+		targetTemperature: low,
+		temperatureUnit: device.temperatureUnit
+	}
+
+	const coolCapabilities = device.capabilities.COOL ?? device.capabilities.AUTO
+
+	if (coolCapabilities && 'fanSpeeds' in coolCapabilities && 'fanSpeed' in device.state) {
+		const currentFanLevel = device.Utils.percentToFanLevel(device.state.fanSpeed, coolCapabilities.fanSpeeds)
+
+		smartModeState.highTemperatureState.fanLevel = currentFanLevel
+		smartModeState.lowTemperatureState.fanLevel = currentFanLevel
+	}
+
+	if ('light' in device.state) {
+		const lightValue = device.state.light ? 'on' : 'off'
+
+		smartModeState.highTemperatureState.light = lightValue
+		smartModeState.lowTemperatureState.light = lightValue
+	}
+
+	if (coolCapabilities) {
+		const swingModes = device.Utils.sensiboFormattedSwingModes(coolCapabilities, device.state)
+
+		Object.assign(smartModeState.highTemperatureState, swingModes)
+		Object.assign(smartModeState.lowTemperatureState, swingModes)
+	}
+
+	log.easyDebug(`${device.name} - climateReactAsAutoMode - AUTO band: HomeKit [${low}, ${high}] -> Climate React [${lowThreshold}, ${high}]`)
+
+	// Assigning the whole object is what triggers StateHandler's setter (and the API call).
+	device.state.smartMode = smartModeState
+}
+
 export default (device, platform) => {
 	Characteristic = platform.api.hap.Characteristic
 	log = platform.log
 	MINIMUM_NODE = platform.MINIMUM_NODE
+	platformRef = platform
 
 	const enableClimateReactAutoSetup = platform.enableClimateReactAutoSetup
 
@@ -190,7 +296,12 @@ export default (device, platform) => {
 			},
 
 			CoolingThresholdTemperature: callback => {
-				const targetTemp = device.state.targetTemperature ?? device.HeaterCoolerService.getCharacteristic(Characteristic.CoolingThresholdTemperature).value
+				// climateReactAsAutoMode: in AUTO the two thumbs are the Climate React band, held in
+				// device.autoBand. Reading state.targetTemperature here would return one value for both
+				// thumbs and collapse the range.
+				const targetTemp = (platform.climateReactAsAutoMode && device.state.mode === 'AUTO')
+					? (device.autoBand.high ?? device.HeaterCoolerService.getCharacteristic(Characteristic.CoolingThresholdTemperature).value)
+					: (device.state.targetTemperature ?? device.HeaterCoolerService.getCharacteristic(Characteristic.CoolingThresholdTemperature).value)
 
 				if (device.usesFahrenheit) {
 					log.easyDebug(device.name, '(GET) - Target Cooling Temperature:', device.Utils.toFahrenheit(targetTemp) + 'ºF')
@@ -202,7 +313,10 @@ export default (device, platform) => {
 			},
 
 			HeatingThresholdTemperature: callback => {
-				const targetTemp = device.state.targetTemperature ?? device.HeaterCoolerService.getCharacteristic(Characteristic.HeatingThresholdTemperature).value
+				// climateReactAsAutoMode: in AUTO this is the bottom of the band (see above).
+				const targetTemp = (platform.climateReactAsAutoMode && device.state.mode === 'AUTO')
+					? (device.autoBand.low ?? device.HeaterCoolerService.getCharacteristic(Characteristic.HeatingThresholdTemperature).value)
+					: (device.state.targetTemperature ?? device.HeaterCoolerService.getCharacteristic(Characteristic.HeatingThresholdTemperature).value)
 
 				if (device.usesFahrenheit) {
 					log.easyDebug(device.name, '(GET) - Target Heating Temperature:', device.Utils.toFahrenheit(targetTemp) + 'ºF')
@@ -499,6 +613,8 @@ export default (device, platform) => {
 				}
 
 				updateClimateReact(device, enableClimateReactAutoSetup)
+				// Turning the accessory off while in AUTO must also switch Climate React off.
+				updateClimateReactAutoMode(device)
 
 				callback()
 			},
@@ -511,6 +627,8 @@ export default (device, platform) => {
 				device.state.active = true
 
 				updateClimateReact(device, enableClimateReactAutoSetup)
+				// Entering AUTO enables Climate React; leaving it for COOL/HEAT disables it.
+				updateClimateReactAutoMode(device)
 
 				callback()
 			},
@@ -525,6 +643,22 @@ export default (device, platform) => {
 				const lastModeValue = device.HeaterCoolerService.getCharacteristic(Characteristic.TargetHeaterCoolerState).value
 				const lastMode = characteristicToMode(lastModeValue)
 
+				// climateReactAsAutoMode: in AUTO this thumb is the TOP of the Climate React band.
+				// Keep it in device.autoBand and don't touch state.targetTemperature - that is a single
+				// value shared by both thumbs and would collapse the range.
+				if (platform.climateReactAsAutoMode && lastMode === 'AUTO') {
+					device.autoBand.high = targetTemp
+					device.autoBand.pending = true
+					device.state.active = true
+					device.state.mode = lastMode
+
+					updateClimateReactAutoMode(device)
+
+					callback()
+
+					return
+				}
+
 				device.state.targetTemperature = targetTemp
 				// TODO: Check on the below. It turns the unit ON if it's currently off. Maybe it's required by API?
 				log.easyDebug(device.name, '(SET) - HeaterCooler State:', lastMode, '(' + lastModeValue + ')')
@@ -532,6 +666,7 @@ export default (device, platform) => {
 				device.state.mode = lastMode
 
 				updateClimateReact(device, enableClimateReactAutoSetup)
+				updateClimateReactAutoMode(device)
 
 				callback()
 			},
@@ -546,6 +681,20 @@ export default (device, platform) => {
 				const lastModeValue = device.HeaterCoolerService.getCharacteristic(Characteristic.TargetHeaterCoolerState).value
 				const lastMode = characteristicToMode(lastModeValue)
 
+				// climateReactAsAutoMode: in AUTO this thumb is the BOTTOM of the Climate React band.
+				if (platform.climateReactAsAutoMode && lastMode === 'AUTO') {
+					device.autoBand.low = targetTemp
+					device.autoBand.pending = true
+					device.state.active = true
+					device.state.mode = lastMode
+
+					updateClimateReactAutoMode(device)
+
+					callback()
+
+					return
+				}
+
 				device.state.targetTemperature = targetTemp
 				// TODO: Check on the below. It turns the unit ON if it's currently off. Maybe it's required by API?
 				log.easyDebug(device.name, '(SET) - HeaterCooler State:', lastMode, '(' + lastModeValue + ')')
@@ -553,6 +702,7 @@ export default (device, platform) => {
 				device.state.mode = lastMode
 
 				updateClimateReact(device, enableClimateReactAutoSetup)
+				updateClimateReactAutoMode(device)
 
 				callback()
 			},

--- a/index.js
+++ b/index.js
@@ -68,6 +68,13 @@ class SensiboACPlatform {
 		this.disableLightSwitch = config['disableLightSwitch'] || false
 		this.disableVerticalSwing = config['disableVerticalSwing'] || false
 		this.enableClimateReactAutoSetup = config['enableClimateReactAutoSetup'] || false
+		// climateReactAsAutoMode: the HomeKit AUTO mode is backed by Climate React instead of the AC's
+		// native AUTO. In AUTO nothing is sent to the AC - Climate React alone cycles the unit.
+		this.climateReactAsAutoMode = config['climateReactAsAutoMode'] || false
+		// Offset added to the LOW threshold sent to Climate React only (HomeKit 23 -> CR 23.2).
+		this.climateReactAutoLowOffset = config['climateReactAutoLowOffset'] ?? 0.2
+		// Coalesce the burst of HomeKit SETs from one range change into a single Climate React POST (avoids HTTP 429).
+		this.climateReactAutoDebounceMs = config['climateReactAutoDebounceMs'] ?? 3000
 		this.enableClimateReactSwitch = config['enableClimateReactSwitch'] || false
 		this.enableHistoryStorage = config['enableHistoryStorage'] || false
 		this.enableOccupancySensor = config['enableOccupancySensor'] || false

--- a/index.js
+++ b/index.js
@@ -82,6 +82,9 @@ class SensiboACPlatform {
 		// Step for the HomeKit AUTO range. Climate React thresholds are triggers, not AC setpoints, so
 		// they may be finer than the whole degrees the AC itself accepts.
 		this.climateReactAutoTemperatureStep = config['climateReactAutoTemperatureStep'] ?? 1
+		// Optional narrower bounds for the AUTO range, so the Home app slider isn't the AC's full span.
+		this.climateReactAutoMinTemperature = config['climateReactAutoMinTemperature'] ?? null
+		this.climateReactAutoMaxTemperature = config['climateReactAutoMaxTemperature'] ?? null
 		this.enableClimateReactSwitch = config['enableClimateReactSwitch'] || false
 		this.enableHistoryStorage = config['enableHistoryStorage'] || false
 		this.enableOccupancySensor = config['enableOccupancySensor'] || false

--- a/index.js
+++ b/index.js
@@ -79,6 +79,9 @@ class SensiboACPlatform {
 		// deliberately independent of the band: the band decides WHEN to run, this decides HOW hard.
 		this.climateReactAutoTargetTemperature = config['climateReactAutoTargetTemperature'] ?? 22
 		this.climateReactAutoFanLevel = config['climateReactAutoFanLevel'] ?? 'low'
+		// Step for the HomeKit AUTO range. Climate React thresholds are triggers, not AC setpoints, so
+		// they may be finer than the whole degrees the AC itself accepts.
+		this.climateReactAutoTemperatureStep = config['climateReactAutoTemperatureStep'] ?? 1
 		this.enableClimateReactSwitch = config['enableClimateReactSwitch'] || false
 		this.enableHistoryStorage = config['enableHistoryStorage'] || false
 		this.enableOccupancySensor = config['enableOccupancySensor'] || false

--- a/index.js
+++ b/index.js
@@ -75,6 +75,10 @@ class SensiboACPlatform {
 		this.climateReactAutoLowOffset = config['climateReactAutoLowOffset'] ?? 0.2
 		// Coalesce the burst of HomeKit SETs from one range change into a single Climate React POST (avoids HTTP 429).
 		this.climateReactAutoDebounceMs = config['climateReactAutoDebounceMs'] ?? 3000
+		// The AC setpoint and fan level Climate React commands when it switches the unit on. These are
+		// deliberately independent of the band: the band decides WHEN to run, this decides HOW hard.
+		this.climateReactAutoTargetTemperature = config['climateReactAutoTargetTemperature'] ?? 22
+		this.climateReactAutoFanLevel = config['climateReactAutoFanLevel'] ?? 'low'
 		this.enableClimateReactSwitch = config['enableClimateReactSwitch'] || false
 		this.enableHistoryStorage = config['enableHistoryStorage'] || false
 		this.enableOccupancySensor = config['enableOccupancySensor'] || false

--- a/sensibo/Utils.js
+++ b/sensibo/Utils.js
@@ -43,6 +43,35 @@ function toCelsiusPrivate(degreesF) {
 }
 
 // FIXME: This files location should move...
+/**
+ * climateReactAsAutoMode: mirror Sensibo's Climate React thresholds back into device.autoBand so HomeKit
+ * shows the range the user set. The stored low threshold carries the configured offset (HomeKit 23 -> CR
+ * 23.2), so it is removed and snapped back to the temperature step. Skipped while a user-initiated update
+ * is in flight (autoBand.pending), otherwise a refresh could overwrite a thumb the user just moved.
+ * @param   {Object}  device                     The accessory
+ * @param   {Object}  platform                   The platform (for config values)
+ * @param   {Object}  deviceFromSensiboResponse  Raw device object from the Sensibo API
+ * @returns {void}
+ */
+function syncAutoBandPrivate(device, platform, deviceFromSensiboResponse) {
+	if (!platform.climateReactAsAutoMode || !device.autoBand || device.autoBand.pending) {
+		return
+	}
+
+	const smartMode = deviceFromSensiboResponse.smartMode
+
+	if (!smartMode || smartMode.highTemperatureThreshold === undefined || smartMode.lowTemperatureThreshold === undefined
+		|| smartMode.highTemperatureThreshold === null || smartMode.lowTemperatureThreshold === null) {
+		return
+	}
+
+	const step = device.usesFahrenheit ? 1.8 : 1
+	const offset = platform.climateReactAutoLowOffset ?? 0.2
+
+	device.autoBand.high = smartMode.highTemperatureThreshold
+	device.autoBand.low = Math.round((smartMode.lowTemperatureThreshold - offset) / step) * step
+}
+
 export default (device, platform) => {
 	const Characteristic = platform.api.hap.Characteristic
 	const Constants = {
@@ -152,6 +181,19 @@ export default (device, platform) => {
 		 *                                               pureBoost(?), light, filterChange, filterLifeLevel, horizontalSwing, verticalSwing
 		 *                                               and fanSpeed
 		 */
+		/**
+		 * climateReactAsAutoMode: mirror Sensibo's Climate React thresholds back into device.autoBand so
+		 * HomeKit shows the range the user set. The stored low threshold carries the configured offset
+		 * (HomeKit 23 -> CR 23.2), so it is removed and snapped back to the temperature step here.
+		 * Skipped while a user-initiated update is in flight (autoBand.pending), otherwise a refresh
+		 * could overwrite a thumb the user just moved before it has even reached Sensibo.
+		 * @param   {Object}  deviceFromSensiboResponse  Raw device object from the Sensibo API
+		 * @returns {void}
+		 */
+		syncAutoBandFromDevice: deviceFromSensiboResponse => {
+			return syncAutoBandPrivate(device, platform, deviceFromSensiboResponse)
+		},
+
 		airConditionerStateFromDevice: deviceFromSensiboResponse => {
 			// TODO: BIG change, but consider moving smartMode out to be a sibling of state, rather than a child
 			// This would have impacts in a number of places, including StateHandler (might need a separate Proxy?), but could simplify
@@ -164,9 +206,20 @@ export default (device, platform) => {
 			// The following is used to ensure the device name is correctly set when logging in "private" functions at the top of this file
 			deviceNamePrivate = device.name
 
+			// climateReactAsAutoMode: Climate React being enabled IS the HomeKit AUTO mode - that is the
+			// single source of truth. We never push a mode to the AC in AUTO, so acState.mode (whatever
+			// Climate React last set it to) must not be allowed to overwrite the HomeKit tile.
+			const climateReactDrivesAuto = !!(platform.climateReactAsAutoMode && deviceFromSensiboResponse.smartMode?.enabled)
+
+			if (climateReactDrivesAuto) {
+				syncAutoBandPrivate(device, platform, deviceFromSensiboResponse)
+			}
+
 			const state = {
-				active: deviceFromSensiboResponse.acState.on,
-				mode: deviceFromSensiboResponse.acState.mode.toUpperCase(),
+				// In AUTO the accessory is "on" whenever Climate React is managing, even while it has the
+				// unit switched off at the bottom of the band.
+				active: climateReactDrivesAuto ? true : deviceFromSensiboResponse.acState.on,
+				mode: climateReactDrivesAuto ? 'AUTO' : deviceFromSensiboResponse.acState.mode.toUpperCase(),
 				// Note: targetTemperature can be null / missing from device.acState when unit is set to FAN (or DRY) mode
 				targetTemperature: !deviceFromSensiboResponse.acState.targetTemperature ? null : deviceFromSensiboResponse.acState.temperatureUnit === 'C' ? deviceFromSensiboResponse.acState.targetTemperature : toCelsiusPrivate(deviceFromSensiboResponse.acState.targetTemperature),
 				currentTemperature: deviceFromSensiboResponse.measurements.temperature,

--- a/sensibo/Utils.js
+++ b/sensibo/Utils.js
@@ -209,7 +209,11 @@ export default (device, platform) => {
 			// climateReactAsAutoMode: Climate React being enabled IS the HomeKit AUTO mode - that is the
 			// single source of truth. We never push a mode to the AC in AUTO, so acState.mode (whatever
 			// Climate React last set it to) must not be allowed to overwrite the HomeKit tile.
-			const climateReactDrivesAuto = !!(platform.climateReactAsAutoMode && deviceFromSensiboResponse.smartMode?.enabled)
+			// autoBand.pending means our own Climate React update is still in flight. Sensibo can briefly
+			// report smartMode.enabled as false while it rewrites that record, and since "enabled" is what
+			// tells us HomeKit is in AUTO, trusting it mid-write would switch the accessory off and back on.
+			const climateReactUpdatePending = !!device.autoBand?.pending
+			const climateReactDrivesAuto = !!(platform.climateReactAsAutoMode && (deviceFromSensiboResponse.smartMode?.enabled || climateReactUpdatePending))
 
 			if (climateReactDrivesAuto) {
 				syncAutoBandPrivate(device, platform, deviceFromSensiboResponse)

--- a/sensibo/Utils.js
+++ b/sensibo/Utils.js
@@ -215,6 +215,11 @@ export default (device, platform) => {
 				syncAutoBandPrivate(device, platform, deviceFromSensiboResponse)
 			}
 
+			// In AUTO the accessory reports itself as active even while Climate React has the unit off,
+			// so keep the AC's real power state separately - it's what tells HomeKit whether we are
+			// actively cooling (COOLING) or waiting for the room to warm up again (IDLE).
+			device.acPowerOn = deviceFromSensiboResponse.acState.on
+
 			const state = {
 				// In AUTO the accessory is "on" whenever Climate React is managing, even while it has the
 				// unit switched off at the bottom of the band.

--- a/sensibo/Utils.js
+++ b/sensibo/Utils.js
@@ -65,7 +65,7 @@ function syncAutoBandPrivate(device, platform, deviceFromSensiboResponse) {
 		return
 	}
 
-	const step = device.usesFahrenheit ? 1.8 : 1
+	const step = device.usesFahrenheit ? 1.8 : (platform.climateReactAutoTemperatureStep ?? 1)
 	const offset = platform.climateReactAutoLowOffset ?? 0.2
 
 	device.autoBand.high = smartMode.highTemperatureThreshold
@@ -849,7 +849,10 @@ export default (device, platform) => {
 			// e.g. CurrentTemperature = "22.60000000000001"
 
 			if (minStep) {
-				const roundedValue = minStep < 1 ? Math.round((newValue + Number.EPSILON) * 10) / 10 : Math.round(newValue + Number.EPSILON)
+				// Round to the actual step, so a minStep of 0.5 snaps to 0.5 rather than to 0.1 or 1.
+				const roundedValue = minStep < 1
+					? Math.round((newValue + Number.EPSILON) / minStep) * minStep
+					: Math.round(newValue + Number.EPSILON)
 
 				if (roundedValue !== newValue) {
 					log.easyDebug(`${device.name} - Utils updateValue - '${newValue}' doesn't meet the rounding required by minStep: ${minStep} for characteristic ${characteristicName} on service ${serviceName}... rounding to ${roundedValue}`)


### PR DESCRIPTION
## What this adds

An opt-in mode (`climateReactAsAutoMode`) where the HomeKit **AUTO** mode is backed by Climate React
(Smart mode) instead of the AC's native AUTO.

The motivation: on many ACs the native AUTO mode only modulates the compressor and keeps the fan running
continuously, which is not what most people want from AUTO. Climate React already does the right thing —
it switches the unit fully off once the room is cool enough and back on when it warms up — but today it is
only reachable as a separate switch, disconnected from the thermostat UI.

This was originally raised in #183 .

## Behaviour

- **COOL** is unchanged — it commands the AC directly, exactly as before.
- **AUTO** sends **no command to the AC at all**. Selecting it enables Climate React, which alone switches
  the unit on and off. The AUTO temperature range sets the Climate React thresholds.
- Switching from AUTO to **COOL**/**HEAT**, or turning the accessory **off**, disables Climate React.
- With the option left off (the default), the plugin behaves exactly as it does today — all changes are
  additive and gated behind the flag.

## New config options

| Option | Default | Purpose |
| ------ | ------- | ------- |
| `climateReactAsAutoMode` | `false` | Enables the feature |
| `climateReactAutoLowOffset` | `0.2` | Offset applied to the **low** threshold only, so a HomeKit range of 23-24 becomes 23.2-24 in Climate React |
| `climateReactAutoTargetTemperature` | `22` | AC setpoint commanded when Climate React switches the unit on |
| `climateReactAutoFanLevel` | `low` | Fan level commanded when Climate React switches the unit on |
| `climateReactAutoTemperatureStep` | `1` | Step for the AUTO range; `0.5` allows ranges like 23.5-24.5 (Celsius only) |
| `climateReactAutoMinTemperature` | – | Narrows the bottom of the temperature slider |
| `climateReactAutoMaxTemperature` | – | Narrows the top of the temperature slider |
| `climateReactAutoDebounceMs` | `3000` | Coalesces the burst of HomeKit SETs from one range change into a single API call |

## Implementation notes

Several decisions are load-bearing, and each corresponds to a bug hit while building this:

- **Climate React being enabled is the source of truth for "HomeKit is in AUTO."** Because AUTO never pushes
  a mode to the AC, `acState.mode` cannot fight the HomeKit tile. An earlier version that sent `cool` to the
  AC in AUTO caused the tile to flip back to COOL on every background refresh.
- **The range is kept in `device.autoBand`, not `state.targetTemperature`.** The latter is a single value
  shared by both range thumbs, which collapsed them onto each other.
- **The low offset applies only to `lowTemperatureThreshold`** (a trigger, which may be fractional).
  `lowTemperatureState.targetTemperature` stays a whole setpoint — Sensibo rejects fractional AC setpoints
  with HTTP 400. The same rounding guards the outgoing `acState`, which matters when the finer 0.5 step is
  enabled.
- **The AC's native `auto` is never sent.** Turning the accessory off while in AUTO still has to reach the
  AC, and that command would otherwise carry `mode: auto` — the very mode this feature exists to avoid,
  left behind in the AC's stored state.
- **Climate React POSTs are debounced, and the payload is built when the value is set**, not when the timer
  fires. A refresh landing inside the debounce window replaces `state.smartMode` with what Sensibo still has
  stored, so building it later sent the previous band back and silently undid the change.
- **Refreshes are ignored while our own update is in flight.** Sensibo can briefly report
  `smartMode.enabled` as false while rewriting that record, which would otherwise read as the user leaving
  AUTO and switch the accessory off.
- **`CurrentHeaterCoolerState` reports `IDLE`** while Climate React has the unit off, rather than always
  reporting `COOLING`, so the Home app tile reflects what the AC is actually doing.

## Testing

Tested against a Sensibo Sky (`skyv2`) on Homebridge v2.4.0 / Node 22, in Celsius:

- Entering AUTO enables Climate React with the mapped thresholds; no acState command is sent.
- Dragging the AUTO range results in a single `/smartmode` call after the debounce, carrying the final band.
- AUTO → COOL sends the acState command and disables Climate React.
- AUTO → off disables Climate React and turns the unit off, leaving the AC in `cool` rather than `auto`.
- The band survives background refreshes and restarts (it is re-derived from Sensibo's stored thresholds).
- Tile shows idle while Climate React waits, cooling while the unit runs.
- 0.5 steps and narrowed bounds behave as expected, with whole-degree setpoints still reaching the AC.

## Known limitations

- **Cooling only.** The low edge switches the unit off rather than heating. Full heat/cool changeover is
  expressible with Climate React's `lowTemperatureState` and could be added later.
- **Celsius tested only.** The offset and step logic has a `usesFahrenheit` branch, but I have no Fahrenheit
  device to verify against. The finer step option is deliberately Celsius-only.
- The cooling/idle indication can lag by up to one polling cycle (~90s), which is inherent to the polling
  interval.
- Not applicable to Dry/Fan, which are separate accessories.

Happy to adjust naming, defaults or the config surface — and equally happy to squash or re-split the commits
if that makes review easier.